### PR TITLE
Precompute the first round of Poseidon8 hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,7 @@ name = "snarkvm-console-program"
 version = "1.1.0"
 dependencies = [
  "bincode",
+ "criterion",
  "enum-iterator",
  "enum_index",
  "enum_index_derive",

--- a/console/algorithms/src/poseidon/hash_many.rs
+++ b/console/algorithms/src/poseidon/hash_many.rs
@@ -34,4 +34,21 @@ impl<E: Environment, const RATE: usize> HashMany for Poseidon<E, RATE> {
         sponge.absorb(&preimage);
         sponge.squeeze(num_outputs).into_vec()
     }
+
+    /// Returns the cryptographic hash for a list of field elements as input,
+    /// and returns the specified number of field elements as output. Utilizes
+    /// a precomputed first round of sponge permutations.
+    #[inline]
+    fn hash_many_precompute(&self, input: &[Self::Input], num_outputs: u16) -> Vec<Self::Output> {
+        // Construct the preimage: [ DOMAIN || LENGTH(INPUT) || [0; RATE-2] || INPUT ].
+        let mut preimage = Vec::with_capacity(RATE + input.len());
+        preimage.push(self.domain);
+        preimage.push(Field::<E>::from_u128(input.len() as u128));
+        preimage.resize(RATE, Field::<E>::zero()); // Pad up to RATE.
+        preimage.extend_from_slice(input);
+
+        let mut sponge = PoseidonSponge::<E, RATE, CAPACITY>::new(&self.parameters);
+        sponge.absorb_precompute(&preimage);
+        sponge.squeeze(num_outputs).into_vec()
+    }
 }

--- a/console/algorithms/src/poseidon/helpers/mod.rs
+++ b/console/algorithms/src/poseidon/helpers/mod.rs
@@ -19,7 +19,7 @@ pub(super) use sponge::*;
 mod state;
 pub(super) use state::*;
 
-use snarkvm_console_types::{Field, prelude::*};
+use snarkvm_console_types::{prelude::*, Field};
 
 use smallvec::SmallVec;
 
@@ -35,6 +35,9 @@ pub trait AlgebraicSponge<E: Environment, const RATE: usize, const CAPACITY: usi
 
     /// Absorb an input into the sponge.
     fn absorb(&mut self, input: &[Field<E>]);
+
+    // Absorb an input into the sponge using a precomputed first round.
+    fn absorb_precompute(&mut self, input: &[Field<E>]);
 
     /// Squeeze `num_elements` field elements from the sponge.
     fn squeeze(&mut self, num_elements: u16) -> SmallVec<[Field<E>; 10]>;

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -14,10 +14,10 @@
 // limitations under the License.
 
 use crate::poseidon::{
-    State,
     helpers::{AlgebraicSponge, DuplexSpongeMode},
+    State,
 };
-use snarkvm_console_types::{Field, prelude::*};
+use snarkvm_console_types::{prelude::*, Field};
 use snarkvm_fields::PoseidonParameters;
 
 use smallvec::SmallVec;
@@ -65,6 +65,24 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> AlgebraicSponge<E
                 DuplexSpongeMode::Squeezing { next_squeeze_index: _ } => {
                     self.permute();
                     self.absorb_internal(0, input);
+                }
+            }
+        }
+    }
+
+    fn absorb_precompute(&mut self, input: &[Field<E>]) {
+        if !input.is_empty() {
+            match self.mode {
+                DuplexSpongeMode::Absorbing { mut next_absorb_index } => {
+                    if next_absorb_index == RATE {
+                        self.permute();
+                        next_absorb_index = 0;
+                    }
+                    self.absorb_internal_precompute(next_absorb_index, input);
+                }
+                DuplexSpongeMode::Squeezing { next_squeeze_index: _ } => {
+                    self.permute();
+                    self.absorb_internal_precompute(0, input);
                 }
             }
         }
@@ -176,6 +194,41 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
                 // If so, let's wrap up.
                 if i == total_num_chunks - 1 {
                     self.mode = DuplexSpongeMode::Absorbing { next_absorb_index: rate_start + chunk.len() };
+
+                    return;
+                } else {
+                    self.permute();
+                }
+                rate_start = 0;
+            }
+        }
+    }
+
+    #[inline]
+    fn absorb_internal_precompute(&mut self, mut rate_start: usize, input: &[Field<E>]) {
+        if !input.is_empty() {
+            let first_chunk_size = std::cmp::min(RATE - rate_start, input.len());
+            let (_first_chunk, rest_chunk) = input.split_at(first_chunk_size);
+            let rest_chunks = rest_chunk.chunks(RATE);
+
+            let mut new_state = State::default();
+            new_state.iter_mut().zip(E::PRECOMPUTED_FIRST_POSEIDON_ROUND).for_each(|(new_elem, hash_elem)| {
+                *new_elem = Field::<E>::new(hash_elem.clone());
+            });
+            self.state = new_state;
+
+            // Absorb the input elements, `RATE` elements at a time, except for the first chunk, which
+            // is of size `RATE - rate_start`.
+            let total_rest_chunks = rest_chunks.len();
+            for (i, chunk) in rest_chunks.enumerate() {
+                for (element, state_elem) in chunk.iter().zip(&mut self.state.rate_state_mut()[rate_start..]) {
+                    *state_elem += element;
+                }
+                // Are we in the last chunk?
+                // If so, let's wrap up.
+                if i == total_rest_chunks - 1 {
+                    self.mode = DuplexSpongeMode::Absorbing { next_absorb_index: rate_start + chunk.len() };
+
                     return;
                 } else {
                     self.permute();

--- a/console/network/environment/src/environment.rs
+++ b/console/network/environment/src/environment.rs
@@ -15,16 +15,12 @@
 
 use crate::prelude::{Deserialize, DeserializeOwned, Serialize};
 use snarkvm_curves::{
-    AffineCurve,
-    MontgomeryParameters,
-    PairingEngine,
-    ProjectiveCurve,
-    TwistedEdwardsParameters,
-    bls12_377::Bls12_377,
+    bls12_377::{Bls12_377, Fr},
     edwards_bls12::{EdwardsAffine, EdwardsParameters},
+    AffineCurve, MontgomeryParameters, PairingEngine, ProjectiveCurve, TwistedEdwardsParameters,
 };
-use snarkvm_fields::{PrimeField, SquareRootField};
-use snarkvm_utilities::BigInteger;
+use snarkvm_fields::{field, PrimeField, SquareRootField};
+use snarkvm_utilities::{BigInteger, BigInteger256};
 
 use core::{fmt::Debug, hash::Hash};
 use zeroize::Zeroize;
@@ -33,11 +29,11 @@ pub trait Environment:
     'static + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync
 {
     type Affine: AffineCurve<
-            Projective = Self::Projective,
-            BaseField = Self::Field,
-            ScalarField = Self::Scalar,
-            Coordinates = (Self::Field, Self::Field),
-        >;
+        Projective = Self::Projective,
+        BaseField = Self::Field,
+        ScalarField = Self::Scalar,
+        Coordinates = (Self::Field, Self::Field),
+    >;
     type BigInteger: BigInteger;
     type Field: PrimeField<BigInteger = Self::BigInteger> + SquareRootField + Copy + Zeroize;
     type PairingCurve: PairingEngine<Fr = Self::Field>;
@@ -56,6 +52,8 @@ pub trait Environment:
 
     /// The maximum number of bytes allowed in a string.
     const MAX_STRING_BYTES: u32 = u8::MAX as u32;
+
+    const PRECOMPUTED_FIRST_POSEIDON_ROUND: [Self::Field; 9];
 
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.
     fn halt<S: Into<String>, T>(message: S) -> T {
@@ -82,4 +80,16 @@ impl Environment for Console {
     const MONTGOMERY_A: Self::Field = <EdwardsParameters as MontgomeryParameters>::MONTGOMERY_A;
     /// The coefficient `B` of the Montgomery curve.
     const MONTGOMERY_B: Self::Field = <EdwardsParameters as MontgomeryParameters>::MONTGOMERY_B;
+    /// The first round of poseidon computations is constant, as the first input is always the encryption domain, which is constant
+    const PRECOMPUTED_FIRST_POSEIDON_ROUND: [Self::Field; 9] = [
+        field!(Fr, BigInteger256([18400883315055711526u64, 2190994228000969506u64, 5206877399204740241u64, 639223570235065050u64])),
+        field!(Fr, BigInteger256([15399590913876696331u64, 15594399395362219105u64, 9529204955545525528u64, 669261489487838935u64])),
+        field!(Fr, BigInteger256([6602557572627535518u64, 9929926631054717162u64, 4515907751056267905u64, 663106168251105715u64])),
+        field!(Fr, BigInteger256([6993747136410928348u64, 18065552776694758143u64, 2408644198368128959u64, 632536464969372654u64])),
+        field!(Fr, BigInteger256([7545327712549990254u64, 4761540785546221362u64, 8841461201722074u64, 1306050386496310916u64])),
+        field!(Fr, BigInteger256([18213014258197997104u64, 13996994921836506268u64, 17734367086959815498u64, 683479563726195903u64])),
+        field!(Fr, BigInteger256([8891171731444413293u64, 15005596550599256007u64, 8255404474136563175u64, 115883256545935591u64])),
+        field!(Fr, BigInteger256([4511196639787990753u64, 13695034759934762127u64, 17467001190581089751u64, 955255359426287200u64])),
+        field!(Fr, BigInteger256([9546547704158379798u64, 16739824303501531796u64, 16409388477121326005u64, 440214594306550130u64])),
+    ];
 }

--- a/console/network/environment/src/traits/algorithms.rs
+++ b/console/network/environment/src/traits/algorithms.rs
@@ -51,6 +51,8 @@ pub trait HashMany {
 
     /// Returns the hash of the given input.
     fn hash_many(&self, input: &[Self::Input], num_outputs: u16) -> Vec<Self::Output>;
+    /// Returns the hash of the given input, using a precomputed first poseidon round.
+    fn hash_many_precompute(&self, input: &[Self::Input], num_outputs: u16) -> Vec<Self::Output>;
 }
 
 /// A trait for a hash function that projects the value to an affine group element.

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -16,22 +16,8 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen128, Pedersen64, Poseidon2, Poseidon4, Poseidon8, Sha3_256,
+    Sha3_384, Sha3_512, BHP1024, BHP256, BHP512, BHP768,
 };
 
 lazy_static! {
@@ -117,6 +103,8 @@ impl Environment for CanaryV0 {
     const MONTGOMERY_A: Self::Field = Console::MONTGOMERY_A;
     /// The coefficient `B` of the Montgomery curve.
     const MONTGOMERY_B: Self::Field = Console::MONTGOMERY_B;
+    /// The precomputed first round of Poseidon sponge permutations.
+    const PRECOMPUTED_FIRST_POSEIDON_ROUND: [Self::Field; 9] = Console::PRECOMPUTED_FIRST_POSEIDON_ROUND;
 }
 
 impl Network for CanaryV0 {
@@ -406,6 +394,11 @@ impl Network for CanaryV0 {
     /// Returns the extended Poseidon hash with an input rate of 8.
     fn hash_many_psd8(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
         CANARY_POSEIDON_8.hash_many(input, num_outputs)
+    }
+
+    // Returns the extended Poseidon hash with an input rate of 8, using a precomputed first round of sponge permutations.
+    fn hash_many_psd8_precompute(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
+        CANARY_POSEIDON_8.hash_many_precompute(input, num_outputs)
     }
 
     /// Returns the BHP hash with an input hasher of 256-bits.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -36,17 +36,17 @@ mod testnet_v0;
 pub use testnet_v0::*;
 
 pub mod prelude {
-    pub use crate::{Network, environment::prelude::*};
+    pub use crate::{environment::prelude::*, Network};
 }
 
 use crate::environment::prelude::*;
 use snarkvm_algorithms::{
-    AlgebraicSponge,
     crypto_hash::PoseidonSponge,
     snark::varuna::{CircuitProvingKey, CircuitVerifyingKey, VarunaHidingMode},
     srs::{UniversalProver, UniversalVerifier},
+    AlgebraicSponge,
 };
-use snarkvm_console_algorithms::{BHP512, BHP1024, Poseidon2, Poseidon4};
+use snarkvm_console_algorithms::{Poseidon2, Poseidon4, BHP1024, BHP512};
 use snarkvm_console_collections::merkle_tree::{MerklePath, MerkleTree};
 use snarkvm_console_types::{Field, Group, Scalar};
 use snarkvm_curves::PairingEngine;
@@ -343,6 +343,9 @@ pub trait Network:
 
     /// Returns the extended Poseidon hash with an input rate of 8.
     fn hash_many_psd8(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>>;
+
+    /// Returns the extended Poseidon hash with an input rate of 8, using a precomputed first round of sponge permutations.
+    fn hash_many_psd8_precompute(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>>;
 
     /// Returns the BHP hash with an input hasher of 256-bits.
     fn hash_to_group_bhp256(input: &[bool]) -> Result<Group<Self>>;

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -15,22 +15,8 @@
 
 use super::*;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen128, Pedersen64, Poseidon2, Poseidon4, Poseidon8, Sha3_256,
+    Sha3_384, Sha3_512, BHP1024, BHP256, BHP512, BHP768,
 };
 
 lazy_static! {
@@ -118,6 +104,8 @@ impl Environment for MainnetV0 {
     const MONTGOMERY_A: Self::Field = Console::MONTGOMERY_A;
     /// The coefficient `B` of the Montgomery curve.
     const MONTGOMERY_B: Self::Field = Console::MONTGOMERY_B;
+    /// The precomputed first round of Poseidon sponge permutations.
+    const PRECOMPUTED_FIRST_POSEIDON_ROUND: [Self::Field; 9] = Console::PRECOMPUTED_FIRST_POSEIDON_ROUND;
 }
 
 impl Network for MainnetV0 {
@@ -423,6 +411,11 @@ impl Network for MainnetV0 {
     /// Returns the extended Poseidon hash with an input rate of 8.
     fn hash_many_psd8(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
         POSEIDON_8.hash_many(input, num_outputs)
+    }
+
+    // Returns the extended Poseidon hash with an input rate of 8, using a precomputed first round of sponge permutations.
+    fn hash_many_psd8_precompute(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
+        POSEIDON_8.hash_many_precompute(input, num_outputs)
     }
 
     /// Returns the BHP hash with an input hasher of 256-bits.

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -16,22 +16,8 @@
 use super::*;
 use crate::TRANSACTION_PREFIX;
 use snarkvm_console_algorithms::{
-    BHP256,
-    BHP512,
-    BHP768,
-    BHP1024,
-    Blake2Xs,
-    Keccak256,
-    Keccak384,
-    Keccak512,
-    Pedersen64,
-    Pedersen128,
-    Poseidon2,
-    Poseidon4,
-    Poseidon8,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+    Blake2Xs, Keccak256, Keccak384, Keccak512, Pedersen128, Pedersen64, Poseidon2, Poseidon4, Poseidon8, Sha3_256,
+    Sha3_384, Sha3_512, BHP1024, BHP256, BHP512, BHP768,
 };
 
 lazy_static! {
@@ -117,6 +103,8 @@ impl Environment for TestnetV0 {
     const MONTGOMERY_A: Self::Field = Console::MONTGOMERY_A;
     /// The coefficient `B` of the Montgomery curve.
     const MONTGOMERY_B: Self::Field = Console::MONTGOMERY_B;
+    /// The precomputed first round of Poseidon sponge permutations.
+    const PRECOMPUTED_FIRST_POSEIDON_ROUND: [Self::Field; 9] = Console::PRECOMPUTED_FIRST_POSEIDON_ROUND;
 }
 
 impl Network for TestnetV0 {
@@ -406,6 +394,11 @@ impl Network for TestnetV0 {
     /// Returns the extended Poseidon hash with an input rate of 8.
     fn hash_many_psd8(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
         TESTNET_POSEIDON_8.hash_many(input, num_outputs)
+    }
+
+    // Returns the extended Poseidon hash with an input rate of 8, using a precomputed first round of sponge permutations.
+    fn hash_many_psd8_precompute(input: &[Field<Self>], num_outputs: u16) -> Vec<Field<Self>> {
+        TESTNET_POSEIDON_8.hash_many_precompute(input, num_outputs)
     }
 
     /// Returns the BHP hash with an input hasher of 256-bits.

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -12,6 +12,16 @@ edition = "2021"
 default = [ ]
 test = [ ]
 
+[[bench]]
+name = "psd8"
+path = "benches/psd8.rs"
+harness = false
+
+[[bench]]
+name = "isOwner"
+path = "benches/isOwner.rs"
+harness = false
+
 [dependencies.snarkvm-console-account]
 path = "../account"
 version = "=1.1.0"
@@ -66,3 +76,6 @@ features = [ "preserve_order" ]
 
 [dev-dependencies.bincode]
 version = "1.3"
+
+[dev-dependencies.criterion]
+version = "0.5.1"

--- a/console/program/benches/isOwner.rs
+++ b/console/program/benches/isOwner.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate criterion;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use snarkvm_console_network::MainnetV0;
+use snarkvm_console_program::{Ciphertext, Group, Record};
+use snarkvm_console_types::{Field, Scalar};
+use snarkvm_utilities::{TestRng, Uniform};
+
+type CurrentNetwork = MainnetV0;
+
+pub fn benchmark_hash_functions(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+    let randomizer = Scalar::rand(rng);
+    let field1 = Field::<CurrentNetwork>::from_u64(u64::rand(rng));
+    let field2 = Field::<CurrentNetwork>::from_u64(u64::rand(rng));
+    let nonce = Group::<CurrentNetwork>::rand(rng);
+
+    c.bench_function("is_owner", |b| {
+        b.iter(|| {
+            Record::<CurrentNetwork, Ciphertext<CurrentNetwork>>::is_owner_direct(field1, randomizer, nonce, field2)
+        });
+    });
+
+    // benchmark is_owner_direct_precompute
+    c.bench_function("is_owner_precompute", |b| {
+        b.iter(|| {
+            Record::<CurrentNetwork, Ciphertext<CurrentNetwork>>::is_owner_direct_precompute(
+                field1, randomizer, nonce, field2,
+            )
+        });
+    });
+}
+
+criterion_group!(benches, benchmark_hash_functions);
+criterion_main!(benches);

--- a/console/program/benches/psd8.rs
+++ b/console/program/benches/psd8.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate criterion;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use snarkvm_console_network::{MainnetV0, Network};
+use snarkvm_console_types::Field;
+use snarkvm_utilities::{TestRng, Uniform};
+
+type CurrentNetwork = MainnetV0;
+
+pub fn benchmark_hash_functions(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+    let some_field_element = Field::<CurrentNetwork>::from_u64(u64::rand(rng));
+    let input = [CurrentNetwork::encryption_domain(), some_field_element];
+
+    c.bench_function("hash_many_psd8", |b| {
+        b.iter(|| CurrentNetwork::hash_many_psd8(&input, 1));
+    });
+
+    c.bench_function("hash_many_psd8_precompute", |b| {
+        b.iter(|| CurrentNetwork::hash_many_psd8_precompute(&input, 1));
+    });
+}
+
+criterion_group!(benches, benchmark_hash_functions);
+criterion_main!(benches);

--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -30,11 +30,27 @@ impl<N: Network> Record<N, Ciphertext<N>> {
         address_x_coordinate: Field<N>,
         view_key_scalar: Scalar<N>,
         record_nonce: Group<N>,
-        record_owner_x_coordinate: Field<N>
+        record_owner_x_coordinate: Field<N>,
     ) -> bool {
         let record_view_key = (record_nonce * view_key_scalar).to_x_coordinate();
         // Compute the 0th randomizer.
         let randomizer = N::hash_many_psd8(&[N::encryption_domain(), record_view_key], 1);
+        // Decrypt the owner.
+        let owner_x = record_owner_x_coordinate - &randomizer[0];
+        // Check if the address is the owner.
+        owner_x == address_x_coordinate
+    }
+
+    /// Returns `true` if the given view key and address x-coordinate corresponds to the owner of the record, using a precomputed first poseidon round.
+    pub fn is_owner_direct_precompute(
+        address_x_coordinate: Field<N>,
+        view_key_scalar: Scalar<N>,
+        record_nonce: Group<N>,
+        record_owner_x_coordinate: Field<N>,
+    ) -> bool {
+        let record_view_key = (record_nonce * view_key_scalar).to_x_coordinate();
+        // Compute the 0th randomizer.
+        let randomizer = N::hash_many_psd8_precompute(&[N::encryption_domain(), record_view_key], 1);
         // Decrypt the owner.
         let owner_x = record_owner_x_coordinate - &randomizer[0];
         // Check if the address is the owner.
@@ -138,5 +154,23 @@ mod tests {
             check_is_owner::<CurrentNetwork>(view_key, owner, &mut rng)?;
         }
         Ok(())
+    }
+
+    #[test]
+    pub fn test_hash_many() {
+        let mut rng = &mut TestRng::default();
+
+        for _ in 0..ITERATIONS {
+            let some_field_element = Field::<CurrentNetwork>::from_u64(u64::rand(&mut rng));
+            let hash_result =
+                CurrentNetwork::hash_many_psd8(&[CurrentNetwork::encryption_domain(), some_field_element], 1);
+
+            let hash_precompute_result = CurrentNetwork::hash_many_psd8_precompute(
+                &[CurrentNetwork::encryption_domain(), some_field_element],
+                1,
+            );
+
+            assert_eq!(hash_result, hash_precompute_result);
+        }
     }
 }


### PR DESCRIPTION
These changes introduce a 50% speedup for the is_owner function, by precomputing the first round of sponge permutations in the underlying poseidon hash. The first input to the poseidon hash is always the encryption domain, which is the same across all current networks (Mainnet, Testnet, Canary).

Example results from the added benchmarks

```
Running benches/psd8.rs (/Users/kevin/Work/snarkVM/target/release/deps/psd8-11d2a59526898601)
Gnuplot not found, using plotters backend

Initializing 'TestRng' with seed '13563277111163056906'

hash_many_psd8          time:   [72.030 µs 72.477 µs 72.936 µs]
                        change: [-2.1449% -1.4361% -0.7400%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

hash_many_psd8_precompute
                        time:   [35.914 µs 36.099 µs 36.302 µs]
                        change: [-66.576% -66.302% -66.017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

```
Running benches/isOwner.rs (/Users/kevin/Work/snarkVM/target/release/deps/isOwner-f45d273707903815)
Gnuplot not found, using plotters backend

Initializing 'TestRng' with seed '10206241736498027169'

is_owner                time:   [114.12 µs 114.87 µs 115.74 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

is_owner_precompute     time:   [78.270 µs 78.655 µs 79.106 µs]
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
```

Downstream in the wasm, syncing speeding up was observed to be ~15% (~14 min down from ~16:30) in the extension wallet.

All benchmarks and tests were run on an M3 mac